### PR TITLE
Updated to a bash script

### DIFF
--- a/roscd.sh
+++ b/roscd.sh
@@ -1,4 +1,5 @@
 # Auto completion
+#!/bin/bash
 _roscd_autocomplete() {
     # Clear previously generated completions
     COMPREPLY=()


### PR DESCRIPTION
The Script is intended to be executed as a shell script. It sets the shebang to /bin/bash to ensure it runs with the Bash shell.

It throw me the following error before:

aaggj@ROS:~/ros/2ros$ source ros2cd/roscd.sh 
bash: ros2cd/roscd.sh: line 17: syntax error near unexpected token `('
bash: ros2cd/roscd.sh: line 17: `roscd() {'
